### PR TITLE
Remove annoying "activated" output

### DIFF
--- a/src/extension.js
+++ b/src/extension.js
@@ -10,7 +10,6 @@ exports.activate = (context) => {
     );
   });
   context.subscriptions.push(revealMe);
-  console.info("Reveal extensions activated!");
 }
 
 exports.deactivate = () => {


### PR DESCRIPTION
I think doing this (logging output in the "everything-is-fine-case") is mostly just noise in the debug console for extension authors and thus bad practice. I have 34 extensions installed, and only one other also does this.